### PR TITLE
Add tools field to json index file

### DIFF
--- a/package_akafugu_index.json
+++ b/package_akafugu_index.json
@@ -38,7 +38,8 @@
           "name": "avrdude",
           "version": "6.0.1-arduino5"
         }
-      ]
+      ],
+      "tools": []
     }
   ]
 }


### PR DESCRIPTION
Missing tools field can cause incompatibility with other Boards Manager packages under Arduino 1.6.4, causing Boards Manager load to fail and then the Arduino IDE to no longer load. For more information see: arduino/Arduino#3248. The Arduino IDE has been fixed to handle missing tools field by arduino/Arduino@1b7574a but that is currently only available in the hourly build or when 1.6.5 comes out.

Screenshot of Boards Manager with the Additional Boards Manager URLs: http://arduino.esp8266.com/package_esp8266com_index.json, https://raw.githubusercontent.com/akafugu/akafugu_core/master/package_akafugu_index.json
![nullpointerexception](https://cloud.githubusercontent.com/assets/8572152/7888945/fc296f06-05f0-11e5-8182-b0d4b7da9468.gif)

Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/akafugu_core/per1234-tools-field/package_akafugu_index.jsonfield/package_carlosefr_atmega_index.json
